### PR TITLE
Reduce Docker image size by switching to Alpine base image

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -29,5 +29,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/myapp:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/myapp:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/stackpilot:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/stackpilot:${{ github.sha }}


### PR DESCRIPTION
This PR updates the Dockerfile to use python:3.11-alpine instead of python:3.11-slim, resulting in a significantly smaller image size and faster build/pull times.