### PR TITLE
Setup Ingress routing for application

### DIFF
--- a/kubernetes/ingress.yml
+++ b/kubernetes/ingress.yml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stackpilot-ingress
+  labels:
+    app: stackpilot
+    app.kubernetes.io/name: stackpilot
+    app.kubernetes.io/instance: stackpilot
+    app.kubernetes.io/version: "1.0.0"
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: stackpilot.shop
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: stackpilot
+            port:
+              number: 80  # Must match with Service `port`

--- a/kubernetes/service.yml
+++ b/kubernetes/service.yml
@@ -15,6 +15,6 @@ spec:
     app.kubernetes.io/version: "1.0.0"
   ports:
     - protocol: TCP 
-      port: 80
-      targetPort: 5000
-  type: NodePort
+      port: 80   # Ingress will call this port
+      targetPort: 5000  # containerPort
+  type: clusterIP


### PR DESCRIPTION
This PR adds the Kubernetes ingress.yml manifest to configure Ingress for routing traffic to the application services. 